### PR TITLE
Update cdk from v1 to v2

### DIFF
--- a/infrastructure/cdk.json
+++ b/infrastructure/cdk.json
@@ -1,13 +1,5 @@
 {
   "app": "mvn -e -q compile exec:java",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true
   }
 }

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -7,7 +7,7 @@
     <version>0.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.0.0</cdk.version>
+        <cdk.version>2.41.0</cdk.version>
         <junit.version>5.8.2</junit.version>
     </properties>
     <build>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>2.0.0</version>
+            <version>${cdk.version}</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -7,7 +7,7 @@
     <version>0.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>1.134.0</cdk.version>
+        <cdk.version>2.0.0</cdk.version>
         <junit.version>5.8.2</junit.version>
     </properties>
     <build>
@@ -35,26 +35,22 @@
         <!-- AWS Cloud Development Kit -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
-            <artifactId>core</artifactId>
-            <version>${cdk.version}</version>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>2.0.0</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
-            <artifactId>apigatewayv2</artifactId>
-            <version>${cdk.version}</version>
+            <artifactId>apigatewayv2-integrations-alpha</artifactId>
+            <version>2.27.0-alpha.0</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>lambda</artifactId>
-            <version>${cdk.version}</version>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>10.1.43</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>apigatewayv2-integrations</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
+
         <dependency>
           <groupId>org.junit.jupiter</groupId>
           <artifactId>junit-jupiter-api</artifactId>

--- a/infrastructure/src/main/java/com/myorg/InfrastructureApp.java
+++ b/infrastructure/src/main/java/com/myorg/InfrastructureApp.java
@@ -1,6 +1,6 @@
 package com.myorg;
 
-import software.amazon.awscdk.core.App;
+import software.amazon.awscdk.App;
 
 public final class InfrastructureApp {
     public static void main(final String[] args) {

--- a/infrastructure/src/main/java/com/myorg/InfrastructureStack.java
+++ b/infrastructure/src/main/java/com/myorg/InfrastructureStack.java
@@ -3,21 +3,22 @@ package com.myorg;
 import java.util.Arrays;
 import java.util.List;
 
-import software.amazon.awscdk.core.BundlingOptions;
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.CfnOutputProps;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.DockerVolume;
-import software.amazon.awscdk.core.Duration;
-import software.amazon.awscdk.core.Stack;
-import software.amazon.awscdk.core.StackProps;
-import software.amazon.awscdk.services.apigatewayv2.AddRoutesOptions;
-import software.amazon.awscdk.services.apigatewayv2.HttpApi;
-import software.amazon.awscdk.services.apigatewayv2.HttpApiProps;
-import software.amazon.awscdk.services.apigatewayv2.HttpMethod;
-import software.amazon.awscdk.services.apigatewayv2.PayloadFormatVersion;
-import software.amazon.awscdk.services.apigatewayv2.integrations.LambdaProxyIntegration;
-import software.amazon.awscdk.services.apigatewayv2.integrations.LambdaProxyIntegrationProps;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.BundlingOptions;
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.CfnOutputProps;
+import software.constructs.Construct;
+import software.amazon.awscdk.DockerVolume;
+import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.apigatewayv2.alpha.AddRoutesOptions;
+import software.amazon.awscdk.services.apigatewayv2.alpha.HttpApi;
+import software.amazon.awscdk.services.apigatewayv2.alpha.HttpApiProps;
+import software.amazon.awscdk.services.apigatewayv2.alpha.HttpMethod;
+import software.amazon.awscdk.services.apigatewayv2.alpha.PayloadFormatVersion;
+import software.amazon.awscdk.services.apigatewayv2.integrations.alpha.HttpLambdaIntegration;
+import software.amazon.awscdk.services.apigatewayv2.integrations.alpha.HttpLambdaIntegrationProps;
 import software.amazon.awscdk.services.lambda.Code;
 import software.amazon.awscdk.services.lambda.Function;
 import software.amazon.awscdk.services.lambda.FunctionProps;
@@ -26,10 +27,10 @@ import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.s3.assets.AssetOptions;
 
 import static java.util.Collections.singletonList;
-import static software.amazon.awscdk.core.BundlingOutput.ARCHIVED;
+import static software.amazon.awscdk.BundlingOutput.ARCHIVED;
 
 public class InfrastructureStack extends Stack {
-    public InfrastructureStack(final Construct parent, final String id) {
+    public InfrastructureStack(final App parent, final String id) {
         this(parent, id, null);
     }
 
@@ -98,8 +99,7 @@ public class InfrastructureStack extends Stack {
         httpApi.addRoutes(AddRoutesOptions.builder()
                 .path("/one")
                 .methods(singletonList(HttpMethod.GET))
-                .integration(new LambdaProxyIntegration(LambdaProxyIntegrationProps.builder()
-                        .handler(functionOne)
+                .integration(new HttpLambdaIntegration("functionOne", functionOne, HttpLambdaIntegrationProps.builder()
                         .payloadFormatVersion(PayloadFormatVersion.VERSION_2_0)
                         .build()))
                 .build());
@@ -107,8 +107,7 @@ public class InfrastructureStack extends Stack {
         httpApi.addRoutes(AddRoutesOptions.builder()
                 .path("/two")
                 .methods(singletonList(HttpMethod.GET))
-                .integration(new LambdaProxyIntegration(LambdaProxyIntegrationProps.builder()
-                        .handler(functionTwo)
+                .integration(new HttpLambdaIntegration("functionTwo", functionTwo, HttpLambdaIntegrationProps.builder()
                         .payloadFormatVersion(PayloadFormatVersion.VERSION_2_0)
                         .build()))
                 .build());

--- a/infrastructure/src/test/java/com/myorg/InfrastructureStackTest.java
+++ b/infrastructure/src/test/java/com/myorg/InfrastructureStackTest.java
@@ -1,6 +1,6 @@
 package com.myorg;
 
-import software.amazon.awscdk.core.App;
+import software.amazon.awscdk.App;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/software/FunctionOne/pom.xml
+++ b/software/FunctionOne/pom.xml
@@ -34,6 +34,7 @@
           <artifactId>aws-lambda-java-events</artifactId>
           <version>3.11.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/software/FunctionTwo/pom.xml
+++ b/software/FunctionTwo/pom.xml
@@ -34,6 +34,7 @@
           <artifactId>aws-lambda-java-events</artifactId>
           <version>3.11.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>


### PR DESCRIPTION
*Issue #, if available:* n/a. With the existing example code, was getting a message at the bottom of the deployment to upgrade the project to use CDK v2. Wanted to migrate the code and get rid of that warning.

*Description of changes:* Updating the example code to use AWS CDK v2 (instead of the v1).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
